### PR TITLE
Don't run a build when non-functional files are updated, plus future-proofing for MessageEvents

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,11 @@ name: Java CI with Maven
 on:
   push:
     branches: [ "bukkit" ]
+    paths-ignore:
+      - '.gitignore'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.github/workflows/*.yml'
   pull_request:
     branches: [ "bukkit" ]
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,6 @@ on:
       - '.gitignore'
       - 'README.md'
       - 'CHANGELOG.md'
-      - '.github/workflows/*.yml'
   pull_request:
     branches: [ "bukkit" ]
 

--- a/src/main/java/com/sidgames5/chatlink/bot/event/MessageEvents.java
+++ b/src/main/java/com/sidgames5/chatlink/bot/event/MessageEvents.java
@@ -2,8 +2,8 @@ package com.sidgames5.chatlink.bot.event;
 
 import com.sidgames5.chatlink.MessageUtil;
 import com.sidgames5.chatlink.PluginConfig;
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
-import net.dv8tion.jda.api.events.message.guild.GuildMessageUpdateEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.bukkit.Bukkit;
 import org.slf4j.Logger;
@@ -11,16 +11,16 @@ import org.slf4j.LoggerFactory;
 
 public class MessageEvents extends ListenerAdapter {
     private static final Logger logger = LoggerFactory.getLogger("ChatLink Bot");
-    public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         String sender = event.getMessage().getAuthor().getName();
         String message = event.getMessage().getContentRaw();
         //logger.info("[DISCORD: " + sender + "] " + message);
-        if (!event.getMessage().getAuthor().isBot() && event.getMessage().getChannel().getId().equals(PluginConfig.get("channelID"))) Bukkit.getServer().broadcastMessage("[DISCORD: " + sender + "] " + MessageUtil.replaceIDwithUsername(message));
+        if (!event.getMessage().getAuthor().isBot() && event.isFromGuild() && event.getMessage().getChannel().getId().equals(PluginConfig.get("channelID"))) Bukkit.getServer().broadcastMessage("[DISCORD: " + sender + "] " + MessageUtil.replaceIDwithUsername(message));
     }
-    public void onGuildMessageUpdate(GuildMessageUpdateEvent event) {
+    public void onMessageUpdate(MessageUpdateEvent event) {
         String sender = event.getMessage().getAuthor().getName();
         String message = event.getMessage().getContentRaw();
-        //logger.info("[DISCORD: " + sender + "] (Edited) " + message);
-        if (!event.getMessage().getAuthor().isBot() && event.getMessage().getChannel().getId().equals(PluginConfig.get("channelID"))) Bukkit.getServer().broadcastMessage("[DISCORD: " + sender + ", Edited] " + MessageUtil.replaceIDwithUsername(message));
+        //logger.info("[DISCORD: " + sender + ", Edited] " + message);
+        if (!event.getMessage().getAuthor().isBot() && event.isFromGuild() && event.getMessage().getChannel().getId().equals(PluginConfig.get("channelID"))) Bukkit.getServer().broadcastMessage("[DISCORD: " + sender + ", Edited] " + MessageUtil.replaceIDwithUsername(message));
     }
 }


### PR DESCRIPTION
Non-functional files include:
- README.md
- CHANGELOG.md
- .gitignore
Guild events will be deprecated in JDA v5.0